### PR TITLE
Add E2E tests for Image Canvas features

### DIFF
--- a/e2e/image-features.spec.ts
+++ b/e2e/image-features.spec.ts
@@ -128,70 +128,111 @@ test.describe('Image Zoom', () => {
   })
 
   test('should zoom in with Shift+Wheel', async ({colourPaletteEditor, page}) => {
-    await colourPaletteEditor.selectColour(0)
-    await colourPaletteEditor.uploadImage(testImagePath)
-    const initialZoom = await colourPaletteEditor.getZoomPercentage()
-
-    await colourPaletteEditor.imageCanvasImage.hover()
-    await page.keyboard.down('Shift')
-
-    await colourPaletteEditor.imageCanvasImage.evaluate((el) => {
-      el.dispatchEvent(new WheelEvent('wheel', {deltaY: -100, shiftKey: true, bubbles: true}))
+    await test.step('setup colour and image', async () => {
+      await colourPaletteEditor.setColour(0, '#FF0000')
+      await colourPaletteEditor.selectColour(0)
+      await colourPaletteEditor.uploadImage(testImagePath)
     })
 
-    await page.keyboard.up('Shift')
+    const initialZoom = await colourPaletteEditor.getZoomPercentage()
+    const initialDimensions = await colourPaletteEditor.getImageDimensions()
 
-    const newZoom = await colourPaletteEditor.getZoomPercentage()
-    expect(newZoom).toBeGreaterThan(initialZoom)
+    await test.step('perform zoom in with Shift+Wheel', async () => {
+      await colourPaletteEditor.imageCanvasImage.hover()
+      await page.keyboard.down('Shift')
+
+      await colourPaletteEditor.imageCanvasImage.evaluate((el) => {
+        el.dispatchEvent(new WheelEvent('wheel', {deltaY: -100, shiftKey: true, bubbles: true}))
+      })
+
+      await page.keyboard.up('Shift')
+    })
+
+    await test.step('verify zoom increased', async () => {
+      const newZoom = await colourPaletteEditor.getZoomPercentage()
+      expect(newZoom).toBeGreaterThan(initialZoom)
+
+      const newDimensions = await colourPaletteEditor.getImageDimensions()
+      expect(newDimensions.width).toBeGreaterThan(initialDimensions.width)
+      expect(newDimensions.height).toBeGreaterThan(initialDimensions.height)
+    })
   })
 
   test('should zoom out with Shift+Wheel', async ({colourPaletteEditor, page}) => {
-    await colourPaletteEditor.selectColour(0)
-    await colourPaletteEditor.uploadImage(testImagePath)
-    const initialZoom = await colourPaletteEditor.getZoomPercentage()
-
-    await colourPaletteEditor.imageCanvasImage.hover()
-    await page.keyboard.down('Shift')
-
-    await colourPaletteEditor.imageCanvasImage.evaluate((el) => {
-      el.dispatchEvent(new WheelEvent('wheel', {deltaY: 100, shiftKey: true, bubbles: true}))
+    await test.step('setup colour and image', async () => {
+      await colourPaletteEditor.setColour(0, '#FF0000')
+      await colourPaletteEditor.selectColour(0)
+      await colourPaletteEditor.uploadImage(testImagePath)
     })
 
-    await page.keyboard.up('Shift')
+    const initialZoom = await colourPaletteEditor.getZoomPercentage()
+    const initialDimensions = await colourPaletteEditor.getImageDimensions()
 
-    const newZoom = await colourPaletteEditor.getZoomPercentage()
-    expect(newZoom).toBeLessThan(initialZoom)
+    await test.step('perform zoom out with Shift+Wheel', async () => {
+      await colourPaletteEditor.imageCanvasImage.hover()
+      await page.keyboard.down('Shift')
+
+      await colourPaletteEditor.imageCanvasImage.evaluate((el) => {
+        el.dispatchEvent(new WheelEvent('wheel', {deltaY: 100, shiftKey: true, bubbles: true}))
+      })
+
+      await page.keyboard.up('Shift')
+    })
+
+    await test.step('verify zoom decreased', async () => {
+      const newZoom = await colourPaletteEditor.getZoomPercentage()
+      expect(newZoom).toBeLessThan(initialZoom)
+
+      const newDimensions = await colourPaletteEditor.getImageDimensions()
+      expect(newDimensions.width).toBeLessThan(initialDimensions.width)
+      expect(newDimensions.height).toBeLessThan(initialDimensions.height)
+    })
   })
 
   test('should zoom in with zoom in button', async ({colourPaletteEditor}) => {
     await colourPaletteEditor.uploadImage(testImagePath)
     const initialZoom = await colourPaletteEditor.getZoomPercentage()
+    const initialDimensions = await colourPaletteEditor.getImageDimensions()
 
     await colourPaletteEditor.imageZoomInButton.click()
 
     const newZoom = await colourPaletteEditor.getZoomPercentage()
     expect(newZoom).toBeGreaterThan(initialZoom)
+
+    const newDimensions = await colourPaletteEditor.getImageDimensions()
+    expect(newDimensions.width).toBeGreaterThan(initialDimensions.width)
+    expect(newDimensions.height).toBeGreaterThan(initialDimensions.height)
   })
 
   test('should zoom out with zoom out button', async ({colourPaletteEditor}) => {
     await colourPaletteEditor.uploadImage(testImagePath)
     const initialZoom = await colourPaletteEditor.getZoomPercentage()
+    const initialDimensions = await colourPaletteEditor.getImageDimensions()
 
     await colourPaletteEditor.imageZoomOutButton.click()
 
     const newZoom = await colourPaletteEditor.getZoomPercentage()
     expect(newZoom).toBeLessThan(initialZoom)
+
+    const newDimensions = await colourPaletteEditor.getImageDimensions()
+    expect(newDimensions.width).toBeLessThan(initialDimensions.width)
+    expect(newDimensions.height).toBeLessThan(initialDimensions.height)
   })
 
   test('should zoom with slider', async ({colourPaletteEditor}) => {
     await colourPaletteEditor.uploadImage(testImagePath)
     const initialZoom = await colourPaletteEditor.getZoomPercentage()
+    const initialDimensions = await colourPaletteEditor.getImageDimensions()
 
     // Move slider to the right (higher value = more zoom)
     await colourPaletteEditor.imageZoomSlider.fill('75')
 
     const newZoom = await colourPaletteEditor.getZoomPercentage()
     expect(newZoom).toBeGreaterThan(initialZoom)
+
+    const newDimensions = await colourPaletteEditor.getImageDimensions()
+    expect(newDimensions.width).toBeGreaterThan(initialDimensions.width)
+    expect(newDimensions.height).toBeGreaterThan(initialDimensions.height)
   })
 })
 
@@ -202,21 +243,22 @@ test.describe('Canvas Hints', () => {
     colourPaletteEditor,
   }) => {
     const hintText = await colourPaletteEditor.getHintText()
-    expect(hintText).toContain('Open')
-    expect(hintText).toContain('paste')
-    expect(hintText).toContain('drop')
+    expect(hintText).toBe('Open, paste or drop an image to get started')
   })
 
   test('should show hint to select colour after image loaded', async ({colourPaletteEditor}) => {
     await colourPaletteEditor.uploadImage(testImagePath)
     await expect(colourPaletteEditor.imageCanvasElement).toBeVisible()
 
-    await expect(colourPaletteEditor.imageCanvasHint).toContainText('Select a colour')
+    await expect(colourPaletteEditor.imageCanvasHint).toHaveText(
+      'Select a colour in the palette to pick colours from the image'
+    )
   })
 
   test('should hide hint when colour is selected and image is loaded', async ({
     colourPaletteEditor,
   }) => {
+    await colourPaletteEditor.setColour(0, '#FF0000')
     await colourPaletteEditor.selectColour(0)
     await colourPaletteEditor.uploadImage(testImagePath)
 

--- a/e2e/pages/ColourPaletteEditor.ts
+++ b/e2e/pages/ColourPaletteEditor.ts
@@ -143,11 +143,11 @@ export class ColourPaletteEditor {
   }
 
   async getImageDimensions(): Promise<{width: number; height: number}> {
-    /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any */
-    const width: number = await this.imageCanvasElement.evaluate((canvas: any) => canvas.width)
-    const height: number = await this.imageCanvasElement.evaluate((canvas: any) => canvas.height)
-    /* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any */
-    return {width, height}
+    const box = await this.imageCanvasElement.boundingBox()
+    if (!box) {
+      throw new Error('Image canvas element not found or not visible')
+    }
+    return {width: box.width, height: box.height}
   }
 
   async getHintText(): Promise<string | null> {

--- a/e2e/pages/ColourPaletteEditor.ts
+++ b/e2e/pages/ColourPaletteEditor.ts
@@ -97,6 +97,10 @@ export class ColourPaletteEditor {
     return this.page.getByTestId('ImageColourPickerImageCanvas Component')
   }
 
+  get imageCanvasImage() {
+    return this.page.getByTestId('ImageColourPickerImageCanvas Image')
+  }
+
   get imageCanvasElement() {
     return this.page.getByTestId('ImageColourPickerImage Canvas')
   }
@@ -111,6 +115,35 @@ export class ColourPaletteEditor {
 
   get imageZoomSlider() {
     return this.page.getByTestId('ImageZoom Slider')
+  }
+
+  get imageZoomInButton() {
+    return this.page.getByTestId('ImageZoom Zoom In')
+  }
+
+  get imageZoomOutButton() {
+    return this.page.getByTestId('ImageZoom Zoom Out')
+  }
+
+  get imageZoomPercentage() {
+    return this.page.getByTestId('ImageZoom Percentage')
+  }
+
+  get imageCanvasHint() {
+    return this.page.getByTestId('ImageColourPickerImageCanvas Hint')
+  }
+
+  get imageDropTarget() {
+    return this.page.getByTestId('ImageColourPickerImageCanvas Drop Target')
+  }
+
+  async getZoomPercentage(): Promise<number> {
+    const text = await this.imageZoomPercentage.textContent()
+    return parseInt(text?.replace('%', '') ?? '100', 10)
+  }
+
+  async getHintText(): Promise<string | null> {
+    return this.imageCanvasHint.textContent()
   }
 
   get openImageButton() {

--- a/e2e/pages/ColourPaletteEditor.ts
+++ b/e2e/pages/ColourPaletteEditor.ts
@@ -142,6 +142,14 @@ export class ColourPaletteEditor {
     return parseInt(text?.replace('%', '') ?? '100', 10)
   }
 
+  async getImageDimensions(): Promise<{width: number; height: number}> {
+    /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any */
+    const width: number = await this.imageCanvasElement.evaluate((canvas: any) => canvas.width)
+    const height: number = await this.imageCanvasElement.evaluate((canvas: any) => canvas.height)
+    /* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any */
+    return {width, height}
+  }
+
   async getHintText(): Promise<string | null> {
     return this.imageCanvasHint.textContent()
   }

--- a/tsconfig.e2e.json
+++ b/tsconfig.e2e.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["ES2023"],
+    "lib": ["ES2023", "dom"],
     "module": "ESNext",
     "skipLibCheck": true,
 


### PR DESCRIPTION
## Summary
Implements comprehensive E2E test coverage for Image Canvas features as specified in issue #13.

## Tests Added

### Canvas Hints (3 tests)
- Verify initial hint to open/paste/drop image is shown
- Verify 'Select a colour' hint appears after image load
- Verify hints disappear when conditions are met

### Drag & Drop (5 tests)
- Verify drop target overlay appears on drag over
- Verify overlay hides on drag leave
- Verify dropping image loads it into canvas
- Verify dropping new image replaces existing one
- Verify non-image files are ignored

### Zoom Controls (7 tests)
- Verify Shift+Wheel zooms in/out
- Verify zoom in/out buttons work
- Verify zoom slider adjusts scale

## Changes
- `e2e/image-features.spec.ts` - Added 15 new tests across 3 describe blocks
- `e2e/pages/ColourPaletteEditor.ts` - Added page object methods for new features
- `tsconfig.e2e.json` - Added 'dom' to lib for browser API types

## Testing
All 66 tests in image-features.spec.ts pass across Chromium, Firefox, and WebKit.

Closes #13